### PR TITLE
Weekly skill update: 2026-07-06

### DIFF
--- a/.claude/skills/agent-orchestration-advisor
+++ b/.claude/skills/agent-orchestration-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/agent-orchestration-advisor

--- a/.claude/skills/company-intel
+++ b/.claude/skills/company-intel
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/company-intel

--- a/.claude/skills/derisk-measurement-advisor
+++ b/.claude/skills/derisk-measurement-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/derisk-measurement-advisor

--- a/.claude/skills/stakeholder-engagement-advisor
+++ b/.claude/skills/stakeholder-engagement-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-engagement-advisor

--- a/.claude/skills/stakeholder-identification
+++ b/.claude/skills/stakeholder-identification
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-identification

--- a/.claude/skills/stakeholder-mapping
+++ b/.claude/skills/stakeholder-mapping
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-mapping


### PR DESCRIPTION
## pm-skills (deanpeters/Product-Manager-Skills)

Submodule bumped from `70fb6c4` → `3998607` (12 new commits, v0.80 → v0.81).

**Skills added (6):**
- `agent-orchestration-advisor` — Design multi-agent AI workflows with clear boundaries, handoffs, and monitoring.
- `company-intel` — Research a company, industry, or competitor set using seven analytical lenses.
- `derisk-measurement-advisor` — Identify what to measure/test to de-risk a product or AI idea.
- `stakeholder-engagement-advisor` — Adapted from MITRE ITK; stakeholder engagement planning.
- `stakeholder-identification` — Adapted from MITRE ITK; identify and profile key stakeholders.
- `stakeholder-mapping` — Adapted from MITRE ITK; map stakeholders by influence and interest.

**Skills updated (content changes):**
- `prd-development` — Overhauled template with per-section coaching, gap tagging, and self-assessment.
- `pm-skill-creator` — Input section added per v0.81 spec.
- `skill-authoring-workflow` — Input section added; inline-input-flow example added.
- `workshop-facilitation` — Inline-input-flow example added.
- All 55 skills — Required `Input` section added as part of v0.81 standardization.

**Skills removed:** none.

## learn-harness-engineering

No submodule configured — directory `ai-skills/learn-harness-engineering` does not exist in this repo. No changes.

---

## Reviewer instructions

Check the linked commits in each skill repo for content changes. When satisfied, merge to bring updated skills into the project. No application code is affected — only symlinks and submodule refs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtvWk92mKits2hyjCP33gU)_