### PR TITLE
Weekly skill update: 2026-07-27

### DIFF
--- a/.claude/skills/agent-orchestration-advisor
+++ b/.claude/skills/agent-orchestration-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/agent-orchestration-advisor

--- a/.claude/skills/ansoff-matrix
+++ b/.claude/skills/ansoff-matrix
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/ansoff-matrix

--- a/.claude/skills/autonomous-investigation
+++ b/.claude/skills/autonomous-investigation
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/autonomous-investigation

--- a/.claude/skills/battle-card-builder
+++ b/.claude/skills/battle-card-builder
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/battle-card-builder

--- a/.claude/skills/company-intel
+++ b/.claude/skills/company-intel
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/company-intel

--- a/.claude/skills/competitive-analysis-process
+++ b/.claude/skills/competitive-analysis-process
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-analysis-process

--- a/.claude/skills/competitive-intel-watch
+++ b/.claude/skills/competitive-intel-watch
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-intel-watch

--- a/.claude/skills/competitive-research-snapshot
+++ b/.claude/skills/competitive-research-snapshot
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-research-snapshot

--- a/.claude/skills/derisk-measurement-advisor
+++ b/.claude/skills/derisk-measurement-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/derisk-measurement-advisor

--- a/.claude/skills/incoming-request-advisor
+++ b/.claude/skills/incoming-request-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/incoming-request-advisor

--- a/.claude/skills/intel-discipline-advisor
+++ b/.claude/skills/intel-discipline-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/intel-discipline-advisor

--- a/.claude/skills/intelligence-collection-disciplines
+++ b/.claude/skills/intelligence-collection-disciplines
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/intelligence-collection-disciplines

--- a/.claude/skills/market-landscape-scan
+++ b/.claude/skills/market-landscape-scan
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/market-landscape-scan

--- a/.claude/skills/pestel-delta-monitor
+++ b/.claude/skills/pestel-delta-monitor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/pestel-delta-monitor

--- a/.claude/skills/porters-five-forces
+++ b/.claude/skills/porters-five-forces
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/porters-five-forces

--- a/.claude/skills/pricing-packaging-tracker
+++ b/.claude/skills/pricing-packaging-tracker
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/pricing-packaging-tracker

--- a/.claude/skills/stakeholder-engagement-advisor
+++ b/.claude/skills/stakeholder-engagement-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-engagement-advisor

--- a/.claude/skills/stakeholder-identification
+++ b/.claude/skills/stakeholder-identification
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-identification

--- a/.claude/skills/stakeholder-mapping
+++ b/.claude/skills/stakeholder-mapping
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-mapping

--- a/.claude/skills/swot-analysis
+++ b/.claude/skills/swot-analysis
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/swot-analysis

--- a/.claude/skills/voice-of-customer-miner
+++ b/.claude/skills/voice-of-customer-miner
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/voice-of-customer-miner


### PR DESCRIPTION
## Summary

Pulls in the latest commits from the `pm-skills` submodule and syncs `.claude/skills/` symlinks to match.

---

## pm-skills (deanpeters/Product-Manager-Skills)

**Submodule bumped:** `70fb6c4` → `9971018`

**Skills added (21):**
- `agent-orchestration-advisor`
- `ansoff-matrix`
- `autonomous-investigation`
- `battle-card-builder`
- `company-intel`
- `competitive-analysis-process`
- `competitive-intel-watch`
- `competitive-research-snapshot`
- `derisk-measurement-advisor`
- `incoming-request-advisor`
- `intel-discipline-advisor`
- `intelligence-collection-disciplines`
- `market-landscape-scan`
- `pestel-delta-monitor`
- `porters-five-forces`
- `pricing-packaging-tracker`
- `stakeholder-engagement-advisor`
- `stakeholder-identification`
- `stakeholder-mapping`
- `swot-analysis`
- `voice-of-customer-miner`

**Skills removed:** none

**Skills updated:** existing skills received content updates in the upstream repo (see submodule commits `70fb6c4..9971018` for details — highlights include v0.80–v0.83 releases covering the Market Intelligence Suite, stakeholder suite, and PRD template overhaul).

---

## learn-harness-engineering

Not present in this repository — no changes.

---

## Reviewer instructions

Check the linked commits in the `pm-skills` submodule (`70fb6c4..9971018` in [deanpeters/Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills)) for content changes to individual skills. When satisfied, merge to bring updated skills into the project. **No application code is affected — only symlinks and submodule refs.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvzVfo3JUsAwLz7xT788Ee)_