### PR TITLE
Weekly skill update: 2026-08-10

### DIFF
--- a/.claude/skills/agent-orchestration-advisor
+++ b/.claude/skills/agent-orchestration-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/agent-orchestration-advisor

--- a/.claude/skills/ansoff-matrix
+++ b/.claude/skills/ansoff-matrix
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/ansoff-matrix

--- a/.claude/skills/autonomous-investigation
+++ b/.claude/skills/autonomous-investigation
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/autonomous-investigation

--- a/.claude/skills/battle-card-builder
+++ b/.claude/skills/battle-card-builder
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/battle-card-builder

--- a/.claude/skills/company-intel
+++ b/.claude/skills/company-intel
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/company-intel

--- a/.claude/skills/competitive-analysis-process
+++ b/.claude/skills/competitive-analysis-process
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-analysis-process

--- a/.claude/skills/competitive-intel-watch
+++ b/.claude/skills/competitive-intel-watch
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-intel-watch

--- a/.claude/skills/competitive-research-snapshot
+++ b/.claude/skills/competitive-research-snapshot
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-research-snapshot

--- a/.claude/skills/derisk-measurement-advisor
+++ b/.claude/skills/derisk-measurement-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/derisk-measurement-advisor

--- a/.claude/skills/eol-checklist
+++ b/.claude/skills/eol-checklist
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-checklist

--- a/.claude/skills/eol-internal-enablement
+++ b/.claude/skills/eol-internal-enablement
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-internal-enablement

--- a/.claude/skills/eol-process
+++ b/.claude/skills/eol-process
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-process

--- a/.claude/skills/eol-readiness-advisor
+++ b/.claude/skills/eol-readiness-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-readiness-advisor

--- a/.claude/skills/eol-stakeholder-sequence
+++ b/.claude/skills/eol-stakeholder-sequence
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-stakeholder-sequence

--- a/.claude/skills/incoming-request-advisor
+++ b/.claude/skills/incoming-request-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/incoming-request-advisor

--- a/.claude/skills/intel-discipline-advisor
+++ b/.claude/skills/intel-discipline-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/intel-discipline-advisor

--- a/.claude/skills/intelligence-collection-disciplines
+++ b/.claude/skills/intelligence-collection-disciplines
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/intelligence-collection-disciplines

--- a/.claude/skills/lifecycle-play-advisor
+++ b/.claude/skills/lifecycle-play-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/lifecycle-play-advisor

--- a/.claude/skills/market-landscape-scan
+++ b/.claude/skills/market-landscape-scan
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/market-landscape-scan

--- a/.claude/skills/pestel-delta-monitor
+++ b/.claude/skills/pestel-delta-monitor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/pestel-delta-monitor

--- a/.claude/skills/porters-five-forces
+++ b/.claude/skills/porters-five-forces
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/porters-five-forces

--- a/.claude/skills/pricing-packaging-tracker
+++ b/.claude/skills/pricing-packaging-tracker
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/pricing-packaging-tracker

--- a/.claude/skills/product-lifecycle-plays
+++ b/.claude/skills/product-lifecycle-plays
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/product-lifecycle-plays

--- a/.claude/skills/stakeholder-engagement-advisor
+++ b/.claude/skills/stakeholder-engagement-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-engagement-advisor

--- a/.claude/skills/stakeholder-identification
+++ b/.claude/skills/stakeholder-identification
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-identification

--- a/.claude/skills/stakeholder-mapping
+++ b/.claude/skills/stakeholder-mapping
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-mapping

--- a/.claude/skills/swot-analysis
+++ b/.claude/skills/swot-analysis
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/swot-analysis

--- a/.claude/skills/voice-of-customer-miner
+++ b/.claude/skills/voice-of-customer-miner
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/voice-of-customer-miner


### PR DESCRIPTION
## Summary

Pulls the latest commits from the `pm-skills` submodule and syncs `.claude/skills/` symlinks to match.

---

### pm-skills — 45 new commits (70fb6c4 → 2447938)

**28 skills added:**
- `agent-orchestration-advisor`
- `ansoff-matrix`
- `autonomous-investigation`
- `battle-card-builder`
- `company-intel`
- `competitive-analysis-process`
- `competitive-intel-watch`
- `competitive-research-snapshot`
- `derisk-measurement-advisor`
- `eol-checklist`
- `eol-internal-enablement`
- `eol-process`
- `eol-readiness-advisor`
- `eol-stakeholder-sequence`
- `incoming-request-advisor`
- `intel-discipline-advisor`
- `intelligence-collection-disciplines`
- `lifecycle-play-advisor`
- `market-landscape-scan`
- `pestel-delta-monitor`
- `porters-five-forces`
- `pricing-packaging-tracker`
- `product-lifecycle-plays`
- `stakeholder-engagement-advisor`
- `stakeholder-identification`
- `stakeholder-mapping`
- `swot-analysis`
- `voice-of-customer-miner`

**49 skills updated** (SKILL.md content changes — all existing skills):
`acquisition-channel-advisor`, `ai-shaped-readiness-advisor`, `altitude-horizon-framework`, `business-health-diagnostic`, `company-research`, `context-engineering-advisor`, `customer-journey-map`, `customer-journey-mapping-workshop`, `director-readiness-advisor`, `discovery-interview-prep`, `discovery-process`, `eol-message`, `epic-breakdown-advisor`, `epic-hypothesis`, `executive-onboarding-playbook`, `feature-investment-advisor`, `finance-based-pricing-advisor`, `finance-metrics-quickref`, `jobs-to-be-done`, `lean-ux-canvas`, `opportunity-solution-tree`, `organic-growth-advisor`, `pestel-analysis`, `pm-skill-creator`, `pol-probe`, `pol-probe-advisor`, `positioning-statement`, `positioning-workshop`, `prd-development`, `press-release`, `prioritization-advisor`, `problem-framing-canvas`, `problem-statement`, `product-sense-interview-answer`, `product-strategy-session`, `proto-persona`, `recommendation-canvas`, `roadmap-planning`, `saas-economics-efficiency-metrics`, `saas-revenue-growth-metrics`, `skill-authoring-workflow`, `storyboard`, `tam-sam-som-calculator`, `user-story`, `user-story-mapping`, `user-story-mapping-workshop`, `user-story-splitting`, `vp-cpo-readiness-advisor`, `workshop-facilitation`

**Skills removed:** none

---

### learn-harness-engineering

Not configured as a submodule in this repository — no changes.

---

## Reviewer instructions

Check the linked commits in each skill repo for content changes. When satisfied, merge to bring updated skills into the project. **No application code is affected — only symlinks and submodule refs.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNUQPx5uupQAZxywnPFf3K)_