### PR TITLE
Weekly skill update: 2026-08-17

### DIFF
--- a/.claude/skills/agent-orchestration-advisor
+++ b/.claude/skills/agent-orchestration-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/agent-orchestration-advisor

--- a/.claude/skills/ansoff-matrix
+++ b/.claude/skills/ansoff-matrix
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/ansoff-matrix

--- a/.claude/skills/autonomous-investigation
+++ b/.claude/skills/autonomous-investigation
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/autonomous-investigation

--- a/.claude/skills/battle-card-builder
+++ b/.claude/skills/battle-card-builder
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/battle-card-builder

--- a/.claude/skills/company-intel
+++ b/.claude/skills/company-intel
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/company-intel

--- a/.claude/skills/competitive-analysis-process
+++ b/.claude/skills/competitive-analysis-process
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-analysis-process

--- a/.claude/skills/competitive-intel-watch
+++ b/.claude/skills/competitive-intel-watch
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-intel-watch

--- a/.claude/skills/competitive-research-snapshot
+++ b/.claude/skills/competitive-research-snapshot
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-research-snapshot

--- a/.claude/skills/derisk-measurement-advisor
+++ b/.claude/skills/derisk-measurement-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/derisk-measurement-advisor

--- a/.claude/skills/eol-checklist
+++ b/.claude/skills/eol-checklist
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-checklist

--- a/.claude/skills/eol-internal-enablement
+++ b/.claude/skills/eol-internal-enablement
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-internal-enablement

--- a/.claude/skills/eol-process
+++ b/.claude/skills/eol-process
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-process

--- a/.claude/skills/eol-readiness-advisor
+++ b/.claude/skills/eol-readiness-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-readiness-advisor

--- a/.claude/skills/eol-stakeholder-sequence
+++ b/.claude/skills/eol-stakeholder-sequence
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-stakeholder-sequence

--- a/.claude/skills/incoming-request-advisor
+++ b/.claude/skills/incoming-request-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/incoming-request-advisor

--- a/.claude/skills/intel-discipline-advisor
+++ b/.claude/skills/intel-discipline-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/intel-discipline-advisor

--- a/.claude/skills/intelligence-collection-disciplines
+++ b/.claude/skills/intelligence-collection-disciplines
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/intelligence-collection-disciplines

--- a/.claude/skills/lifecycle-play-advisor
+++ b/.claude/skills/lifecycle-play-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/lifecycle-play-advisor

--- a/.claude/skills/market-landscape-scan
+++ b/.claude/skills/market-landscape-scan
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/market-landscape-scan

--- a/.claude/skills/pestel-delta-monitor
+++ b/.claude/skills/pestel-delta-monitor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/pestel-delta-monitor

--- a/.claude/skills/porters-five-forces
+++ b/.claude/skills/porters-five-forces
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/porters-five-forces

--- a/.claude/skills/pricing-packaging-tracker
+++ b/.claude/skills/pricing-packaging-tracker
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/pricing-packaging-tracker

--- a/.claude/skills/product-lifecycle-plays
+++ b/.claude/skills/product-lifecycle-plays
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/product-lifecycle-plays

--- a/.claude/skills/stakeholder-engagement-advisor
+++ b/.claude/skills/stakeholder-engagement-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-engagement-advisor

--- a/.claude/skills/stakeholder-identification
+++ b/.claude/skills/stakeholder-identification
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-identification

--- a/.claude/skills/stakeholder-mapping
+++ b/.claude/skills/stakeholder-mapping
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-mapping

--- a/.claude/skills/swot-analysis
+++ b/.claude/skills/swot-analysis
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/swot-analysis

--- a/.claude/skills/voice-of-customer-miner
+++ b/.claude/skills/voice-of-customer-miner
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/voice-of-customer-miner


### PR DESCRIPTION
## pm-skills (deanpeters/Product-Manager-Skills)

**Updated:** `70fb6c4` → `a03af68` (53 commits)

**Skills added (28):**
- `agent-orchestration-advisor` — Design multi-agent AI workflows
- `ansoff-matrix` — Map evidence-backed growth options with risk-rated sequencing
- `autonomous-investigation` — AI research protocol with search-plan gate and labeled outputs
- `battle-card-builder` — Competitive battle cards from public evidence
- `company-intel` — Structured company/industry/competitor research across seven lenses
- `competitive-analysis-process` — Complete six-step competitive analysis orchestration
- `competitive-intel-watch` — Scheduled delta monitoring against prior competitive snapshots
- `competitive-research-snapshot` — Cited competitive landscape snapshots with comparison matrix
- `derisk-measurement-advisor` — Identify what to measure/test to de-risk product/AI ideas
- `eol-checklist` — Phase-gated EOL checklist with named owners
- `eol-internal-enablement` — Internal team enablement before EOL announcement
- `eol-process` — End-to-end product sunset orchestration
- `eol-readiness-advisor` — Go/no-go assessment for retiring a product or feature
- `eol-stakeholder-sequence` — Stakeholder conversation sequencing for sunsets
- `incoming-request-advisor` — Decode loaded messages into structured job-to-be-done breakdowns
- `intel-discipline-advisor` — Triage competitive/market questions into right intelligence disciplines
- `intelligence-collection-disciplines` — Eight intelligence collection disciplines (OSINT to MASINT)
- `lifecycle-play-advisor` — Product lifecycle plays and strategic options
- `market-landscape-scan` — Structured market landscape research
- `pestel-delta-monitor` — PESTEL monitoring for environmental signal changes
- `porters-five-forces` — Porter's Five Forces competitive structure analysis
- `pricing-packaging-tracker` — Track competitor pricing and packaging changes
- `product-lifecycle-plays` — Playbook of moves by lifecycle stage
- `stakeholder-engagement-advisor` — Structured stakeholder engagement planning
- `stakeholder-identification` — Identify and classify stakeholders for a product initiative
- `stakeholder-mapping` — Map stakeholders by influence, interest, and action
- `swot-analysis` — Structured SWOT with evidence and strategic implications
- `voice-of-customer-miner` — Systematic VOC mining from existing data

**Skills removed:** none

**Skills updated:** all 49 existing skills received content updates (templates, examples, metadata backfill across waves per upstream Adornment Plan 4)

## learn-harness-engineering

Not present in this repository — skipped.

## Reviewer instructions

Check the linked commits in each skill repo for content changes:
- pm-skills changes: https://github.com/deanpeters/Product-Manager-Skills/compare/70fb6c4...a03af68

When satisfied, merge to bring updated skills into the project. No application code is affected — only symlinks and submodule refs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BK5iJ5XBGJDJJq2jWt71J8)_