### PR TITLE
Weekly skill update: 2026-09-07

### DIFF
--- a/.claude/skills/agent-orchestration-advisor
+++ b/.claude/skills/agent-orchestration-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/agent-orchestration-advisor

--- a/.claude/skills/ansoff-matrix
+++ b/.claude/skills/ansoff-matrix
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/ansoff-matrix

--- a/.claude/skills/autonomous-investigation
+++ b/.claude/skills/autonomous-investigation
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/autonomous-investigation

--- a/.claude/skills/battle-card-builder
+++ b/.claude/skills/battle-card-builder
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/battle-card-builder

--- a/.claude/skills/company-intel
+++ b/.claude/skills/company-intel
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/company-intel

--- a/.claude/skills/competitive-analysis-process
+++ b/.claude/skills/competitive-analysis-process
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-analysis-process

--- a/.claude/skills/competitive-intel-watch
+++ b/.claude/skills/competitive-intel-watch
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-intel-watch

--- a/.claude/skills/competitive-research-snapshot
+++ b/.claude/skills/competitive-research-snapshot
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/competitive-research-snapshot

--- a/.claude/skills/derisk-measurement-advisor
+++ b/.claude/skills/derisk-measurement-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/derisk-measurement-advisor

--- a/.claude/skills/eol-checklist
+++ b/.claude/skills/eol-checklist
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-checklist

--- a/.claude/skills/eol-internal-enablement
+++ b/.claude/skills/eol-internal-enablement
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-internal-enablement

--- a/.claude/skills/eol-process
+++ b/.claude/skills/eol-process
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-process

--- a/.claude/skills/eol-readiness-advisor
+++ b/.claude/skills/eol-readiness-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-readiness-advisor

--- a/.claude/skills/eol-stakeholder-sequence
+++ b/.claude/skills/eol-stakeholder-sequence
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/eol-stakeholder-sequence

--- a/.claude/skills/incoming-request-advisor
+++ b/.claude/skills/incoming-request-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/incoming-request-advisor

--- a/.claude/skills/intel-discipline-advisor
+++ b/.claude/skills/intel-discipline-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/intel-discipline-advisor

--- a/.claude/skills/intelligence-collection-disciplines
+++ b/.claude/skills/intelligence-collection-disciplines
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/intelligence-collection-disciplines

--- a/.claude/skills/lifecycle-play-advisor
+++ b/.claude/skills/lifecycle-play-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/lifecycle-play-advisor

--- a/.claude/skills/market-landscape-scan
+++ b/.claude/skills/market-landscape-scan
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/market-landscape-scan

--- a/.claude/skills/pestel-delta-monitor
+++ b/.claude/skills/pestel-delta-monitor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/pestel-delta-monitor

--- a/.claude/skills/porters-five-forces
+++ b/.claude/skills/porters-five-forces
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/porters-five-forces

--- a/.claude/skills/pricing-packaging-tracker
+++ b/.claude/skills/pricing-packaging-tracker
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/pricing-packaging-tracker

--- a/.claude/skills/product-lifecycle-plays
+++ b/.claude/skills/product-lifecycle-plays
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/product-lifecycle-plays

--- a/.claude/skills/stakeholder-engagement-advisor
+++ b/.claude/skills/stakeholder-engagement-advisor
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-engagement-advisor

--- a/.claude/skills/stakeholder-identification
+++ b/.claude/skills/stakeholder-identification
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-identification

--- a/.claude/skills/stakeholder-mapping
+++ b/.claude/skills/stakeholder-mapping
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/stakeholder-mapping

--- a/.claude/skills/swot-analysis
+++ b/.claude/skills/swot-analysis
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/swot-analysis

--- a/.claude/skills/voice-of-customer-miner
+++ b/.claude/skills/voice-of-customer-miner
@@ -1,0 +1,1 @@
+../../ai-skills/pm-skills/skills/voice-of-customer-miner


### PR DESCRIPTION
## What changed

### pm-skills (`ai-skills/pm-skills`)

Submodule updated from `70fb6c4` → `1b5a524` (upstream: [deanpeters/Product-Manager-Skills](https://github.com/deanpeters/Product-Manager-Skills)).

**28 new skills added** (symlinks created in `.claude/skills/`):
- `agent-orchestration-advisor` — design multi-agent AI workflows
- `ansoff-matrix` — map growth options across the Ansoff Matrix
- `autonomous-investigation` — unattended AI research protocol
- `battle-card-builder` — competitive battle cards from public evidence
- `company-intel` — structured intel via seven analytical lenses
- `competitive-analysis-process` — full six-step competitive analysis
- `competitive-intel-watch` — scheduled delta monitoring of competitors
- `competitive-research-snapshot` — cited competitive landscape snapshot
- `derisk-measurement-advisor` — identify what to measure to de-risk ideas
- `eol-checklist` — phase-gated EOL checklist with owners
- `eol-internal-enablement` — internal FAQ and objection handling for EOL
- `eol-process` — end-to-end product sunset orchestration
- `eol-readiness-advisor` — go/no-go assessment for retiring a product
- `eol-stakeholder-sequence` — EOL stakeholder sequencing plan
- `incoming-request-advisor` — decode loaded messages into structured breakdowns
- `intel-discipline-advisor` — triage competitive questions to the right discipline
- `intelligence-collection-disciplines` — eight-channel intelligence fusion
- `lifecycle-play-advisor` — product lifecycle plays
- `market-landscape-scan` — cited market landscape scans
- `pestel-delta-monitor` — monitor PESTEL changes on a cadence
- `porters-five-forces` — Porter's Five Forces analysis
- `pricing-packaging-tracker` — track competitor pricing and packaging
- `product-lifecycle-plays` — plays across the product lifecycle
- `stakeholder-engagement-advisor` — stakeholder engagement strategy
- `stakeholder-identification` — structured stakeholder identification
- `stakeholder-mapping` — stakeholder mapping with influence/interest grid
- `swot-analysis` — evidence-backed SWOT analysis
- `voice-of-customer-miner` — mine VOC from interviews and feedback

**5 existing skills updated** (content changed, symlinks unchanged):
- `eol-message` — expanded with industrial examples and updated template
- `organic-growth-advisor` — minor updates
- `pm-skill-creator` — updated authoring workflow
- `prd-development` — major template overhaul with per-section coaching
- `skill-authoring-workflow` — added examples and template

**No skills removed.**

### learn-harness-engineering

This repo is not present in `ai-skills/` and is not registered as a submodule — no changes.

---

## Reviewer instructions

Check the linked commits in each skill repo for content changes. When satisfied, merge to bring updated skills into the project. No application code is affected — only symlinks and submodule refs.

pm-skills commit range: https://github.com/deanpeters/Product-Manager-Skills/compare/70fb6c4e41637047e7e4976d39145b1a78397464...1b5a524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBtoUAqX4bQspGhA5e68De

---
_Generated by [Claude Code](https://claude.ai/code/session_01RBtoUAqX4bQspGhA5e68De)_